### PR TITLE
Potential fix for code scanning alert no. 4: Server-side request forgery

### DIFF
--- a/lessons/standard-integration/paypal-api.js
+++ b/lessons/standard-integration/paypal-api.js
@@ -29,6 +29,9 @@ export async function createOrder() {
 }
 
 export async function capturePayment(orderId) {
+  if (!isValidOrderId(orderId)) {
+    throw new Error("Invalid order ID");
+  }
   const accessToken = await generateAccessToken();
   const url = `${base}/v2/checkout/orders/${orderId}/capture`;
   const response = await fetch(url, {
@@ -63,4 +66,8 @@ async function handleResponse(response) {
 
   const errorMessage = await response.text();
   throw new Error(errorMessage);
+}
+function isValidOrderId(orderId) {
+  const orderIdPattern = /^[A-Z0-9]{17}$/; // Example pattern, adjust as needed
+  return orderIdPattern.test(orderId);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/InfoMKalpanaDemo/paypal-docs-examples/security/code-scanning/4](https://github.com/InfoMKalpanaDemo/paypal-docs-examples/security/code-scanning/4)

To fix the problem, we need to validate the `orderID` before using it to construct the URL for the PayPal API request. The best way to do this is to ensure that the `orderID` matches the expected format for PayPal order IDs. This can be done using a regular expression or a similar validation method.

1. Add a validation function to check the format of the `orderID`.
2. Use this validation function in the `capturePayment` function before constructing the URL.
3. If the `orderID` is invalid, throw an error or return an appropriate response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
